### PR TITLE
Capturing BuddyMatch in database

### DIFF
--- a/Backend/prisma/migrations/20250716203144_storing_match_information/migration.sql
+++ b/Backend/prisma/migrations/20250716203144_storing_match_information/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "Match" (
+    "id" SERIAL NOT NULL,
+    "userId" INTEGER NOT NULL,
+    "buddyId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Match_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Match" ADD CONSTRAINT "Match_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Match" ADD CONSTRAINT "Match_buddyId_fkey" FOREIGN KEY ("buddyId") REFERENCES "BuddyPair"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/Backend/prisma/schema.prisma
+++ b/Backend/prisma/schema.prisma
@@ -29,6 +29,7 @@ model User{
 	createdAt		  DateTime @default (now())
 	updatedAt		  DateTime @updatedAt
 	passwordConfirmation String @default("")
+	match 			  Match[] @relation("Match")
 }
 model BuddyRequest {
 	id 	              Int @id @default(autoincrement())
@@ -64,6 +65,7 @@ model BuddyPair{
 	confirmed          Boolean @default(false)
 	confirmedAt        DateTime?
 	createdAt          DateTime @default(now())
+	match 			   Match[] @relation("BuddyMatch")
 }
 enum RequestStatus{
 	PENDING
@@ -80,4 +82,13 @@ model Location{
 	meetingPointRequests BuddyRequest[] @relation("RequestMeeting")
 	destinationRequestsPair BuddyPair[] @relation("Destination")
 	locationRequestsPair BuddyPair[] @relation("Location")
+}
+
+model Match{
+	id         Int @id @default(autoincrement())
+	userId     Int
+	user       User  @relation("Match", fields: [userId], references:[id])
+	buddyId    Int
+	buddyPair  BuddyPair  @relation("BuddyMatch", fields: [buddyId], references:[id])
+	createdAt  DateTime @default(now())
 }

--- a/Backend/routes/Auth.js
+++ b/Backend/routes/Auth.js
@@ -399,4 +399,30 @@ async function matchedBuddy(date, time, destinationId, meetingPointId, userId) {
   }
 }
 
+router.post("/match", async (req, res) => {
+  if (!req.session.userId) {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+  try {
+    const { buddyPair } = req.body;
+    const matchedPair = await prisma.match.create({
+      data: {
+        buddyPair: {
+          connect: { id: Number(buddyPair) },
+        },
+        user: {
+          connect: { id: req.session.userId },
+        },
+      },
+    });
+    res.status(201).json({
+      success: true,
+      message: "Match captured",
+    });
+  } catch (error) {
+    console.error("Error while capturing match");
+    res.status(500).json({ error: error.message || "Internal server error" });
+  }
+});
+
 export default router;


### PR DESCRIPTION
### Description
This pull request implements the server-side logic for capturing when a user pairs with a buddy, laying the foundation for push notifications. Future PRs will focus on implementing client-side capture.
### Milestones
This PR contributes to completing Technical Challenge 2.
### Test Plan
The new route was thoroughly tested using Insomnia. 
A screenshot of the test results is attached for review.
<img width="500" height="500" alt="Screenshot 2025-07-16 at 1 54 40 PM" src="https://github.com/user-attachments/assets/60ec7152-fdd5-43d9-bd3d-29e569d65dc6" />
